### PR TITLE
参照画面の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,10 @@ gem "rails-i18n", "~> 6.0"
 gem "devise-i18n"
 
 # Bootstrap
-gem 'devise-bootstrap-views', '~> 1.0'
+gem "devise-bootstrap-views", "~> 1.0"
+
+# config / locales / ja.yml生成
+gem "i18n_generators"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    i18n_generators (2.2.2)
+      activerecord (>= 3.0.0)
+      railties (>= 3.0.0)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     listen (3.5.1)
@@ -210,6 +213,7 @@ DEPENDENCIES
   devise
   devise-bootstrap-views (~> 1.0)
   devise-i18n
+  i18n_generators
   jbuilder (~> 2.7)
   listen (~> 3.3)
   pg (~> 1.1)

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -5,6 +5,7 @@ class IncidentsController < ApplicationController
   end
 
   def show
+    @incident = Incident.find(params[:id])
   end
 
   def new

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -5,10 +5,16 @@
   <p class="col-10"><%= l @incident.created_at, format: :default %></p>
 </div>
 
+<div class="show-updated-time row">
+  <p class="col-2">更新日時</p>
+  <p class="col-10"><%= l @incident.updated_at, format: :default %></p>
+</div>
+
 <div class="show-incident row">
   <p class="col-2">事象</p>
   <p class = "border bg-light col-10"><%= @incident.incident %></p>
 </div>
+
 <div class="show-solution row">
   <p class="col-2">解決方法</p>
   <p class = "border bg-light col-10"><%= safe_join(@incident.solution.split("\n"), tag(:br)) %></p>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,6 +1,10 @@
 <h1>参照</h1>
 <h2>No.<%= @incident.id %></h2>
-<p>事象</p>
-<p class = "border bg-light"><%= @incident.incident %></p>
-<p>解決方法</p>
-<p class = "border bg-light"><%= safe_join(@incident.solution.split("\n"), tag(:br)) %></p>
+<div class="show-incident row">
+  <p class="col-2">事象</p>
+  <p class = "border bg-light col-10"><%= @incident.incident %></p>
+</div>
+<div class="show-solution row">
+  <p class="col-2">解決方法</p>
+  <p class = "border bg-light col-10"><%= safe_join(@incident.solution.split("\n"), tag(:br)) %></p>
+</div>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,5 +1,5 @@
 <h1>参照</h1>
-<h2>No.<%= sprintf("%008d", @incident.id) %></h2>
+<h2 class="border-bottom border-dark">No.<%= sprintf("%008d", @incident.id) %></h2>
 <div class="show-created-time row">
   <p class="col-2">作成日時</p>
   <p class="col-10"><%= l @incident.created_at, format: :default %></p>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,5 +1,5 @@
 <h1>参照</h1>
-<h2>No.<%= @incident.id %></h2>
+<h2>No.<%= sprintf("%008d", @incident.id) %></h2>
 <div class="show-created-time row">
   <p class="col-2">作成日時</p>
   <p class="col-10"><%= l @incident.created_at, format: :default %></p>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,6 +1,10 @@
 <h1>参照</h1>
 <h2>No.<%= @incident.id %></h2>
-<p><%= l @incident.created_at%></p>
+<div class="show-created-time row">
+  <p class="col-2">作成日時</p>
+  <p class="col-10"><%= l @incident.created_at, format: :default %></p>
+</div>
+
 <div class="show-incident row">
   <p class="col-2">事象</p>
   <p class = "border bg-light col-10"><%= @incident.incident %></p>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,5 +1,6 @@
 <h1>参照</h1>
 <h2>No.<%= @incident.id %></h2>
+<p><%= l @incident.created_at%></p>
 <div class="show-incident row">
   <p class="col-2">事象</p>
   <p class = "border bg-light col-10"><%= @incident.incident %></p>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,4 +1,6 @@
 <h1>参照</h1>
 <h2>No.<%= @incident.id %></h2>
-<p>事象<%= @incident.incident %></p>
-<p>解決方法<%= @incident.solution %></p>
+<p>事象</p>
+<p class = "border bg-light"><%= @incident.incident %></p>
+<p>解決方法</p>
+<p class = "border bg-light"><%= safe_join(@incident.solution.split("\n"), tag(:br)) %></p>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,2 +1,4 @@
-<h1>Incidents#show</h1>
-<p>Find me in app/views/incidents/show.html.erb</p>
+<h1>参照</h1>
+<h2>No.<%= @incident.id %></h2>
+<p>事象<%= @incident.incident %></p>
+<p>解決方法<%= @incident.solution %></p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,207 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    - 
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+    prompts:
+      second: 秒
+      minute: 分
+      hour: 時
+      day: 日
+      month: 月
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      other_than: は%{count}以外の値にしてください
+      present: は入力しないでください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: "、"
+      two_words_connector: "、"
+      words_connector: "、"
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,63 +3,63 @@ ja:
   activerecord:
     errors:
       messages:
-        record_invalid: 'バリデーションに失敗しました: %{errors}'
+        record_invalid: "バリデーションに失敗しました: %{errors}"
         restrict_dependent_destroy:
           has_one: "%{record}が存在しているので削除できません"
           has_many: "%{record}が存在しているので削除できません"
   date:
     abbr_day_names:
-    - 日
-    - 月
-    - 火
-    - 水
-    - 木
-    - 金
-    - 土
+      - 日
+      - 月
+      - 火
+      - 水
+      - 木
+      - 金
+      - 土
     abbr_month_names:
-    - 
-    - 1月
-    - 2月
-    - 3月
-    - 4月
-    - 5月
-    - 6月
-    - 7月
-    - 8月
-    - 9月
-    - 10月
-    - 11月
-    - 12月
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
     day_names:
-    - 日曜日
-    - 月曜日
-    - 火曜日
-    - 水曜日
-    - 木曜日
-    - 金曜日
-    - 土曜日
+      - 日曜日
+      - 月曜日
+      - 火曜日
+      - 水曜日
+      - 木曜日
+      - 金曜日
+      - 土曜日
     formats:
       default: "%Y/%m/%d"
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
     month_names:
-    - 
-    - 1月
-    - 2月
-    - 3月
-    - 4月
-    - 5月
-    - 6月
-    - 7月
-    - 8月
-    - 9月
-    - 10月
-    - 11月
-    - 12月
+      -
+      - 1月
+      - 2月
+      - 3月
+      - 4月
+      - 5月
+      - 6月
+      - 7月
+      - 8月
+      - 9月
+      - 10月
+      - 11月
+      - 12月
     order:
-    - :year
-    - :month
-    - :day
+      - :year
+      - :month
+      - :day
   datetime:
     distance_in_words:
       about_x_hours:
@@ -122,7 +122,7 @@ ja:
       invalid: は不正な値です
       less_than: は%{count}より小さい値にしてください
       less_than_or_equal_to: は%{count}以下の値にしてください
-      model_invalid: 'バリデーションに失敗しました: %{errors}'
+      model_invalid: "バリデーションに失敗しました: %{errors}"
       not_a_number: は数値で入力してください
       not_an_integer: は整数で入力してください
       odd: は奇数にしてください
@@ -170,9 +170,9 @@ ja:
           quadrillion: 千兆
           thousand: 千
           trillion: 兆
-          unit: ''
+          unit: ""
       format:
-        delimiter: ''
+        delimiter: ""
         precision: 3
         significant: true
         strip_insignificant_zeros: true
@@ -188,11 +188,11 @@ ja:
           tb: TB
     percentage:
       format:
-        delimiter: ''
+        delimiter: ""
         format: "%n%"
     precision:
       format:
-        delimiter: ''
+        delimiter: ""
   support:
     array:
       last_word_connector: "、"
@@ -201,7 +201,7 @@ ja:
   time:
     am: 午前
     formats:
-      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒"
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後


### PR DESCRIPTION
## issue 番号

close #16 

## 実装内容

- 参照画面の実装
　- 事象を表示
　- 解決方法を複数行で表示 
　- 作成日時を表示
　- 更新日時を表示
- ja.ymlの追加
- idを8桁で表示
- 
## 参考資料

- [railsでtext_areaで入力したまま表示する（改行、段落）](https://qiita.com/kamotetu/items/1aa94994985c720668e4)
- [【format】引数でよく見かける'%010d'の実態を解明[Ruby]](https://qiita.com/takuyanin/items/3b210f166f24c6d13e5a)
- [Borders](https://getbootstrap.jp/docs/4.2/utilities/borders/)
- [【初心者向け・動画付き】Railsで日時をフォーマットするときはstrftimeよりも、lメソッドを使おう](https://qiita.com/jnchito/items/831654253fb8a958ec25)
## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）

## 備考（必要があれば）
