### PR TITLE
更新画面の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -92,3 +92,6 @@ main{
 // .event_table tr:hover {
 //   background-color: #d9efff;
 // }
+
+
+// show

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -95,3 +95,10 @@ main{
 
 
 // show
+.show-header{
+  display: flex;
+  width: 100%;
+  .update-buttom{
+    margin-left: auto;
+  }
+}

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -28,6 +28,9 @@ class IncidentsController < ApplicationController
   end
 
   def destroy
+    incident = Incident.find(params[:id])
+    incident.destroy!
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -18,9 +18,13 @@ class IncidentsController < ApplicationController
   end
 
   def edit
+    @incident = Incident.find(params[:id])
   end
 
   def update
+    incident = Incident.find(params[:id])
+    incident.update!(incident_params)
+    redirect_to incident
   end
 
   def destroy

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -14,7 +14,7 @@ class IncidentsController < ApplicationController
 
   def create
     incident = Incident.create!(incident_params)
-    redirect_to incident
+    redirect_to incident,  notice: "作成しました"
   end
 
   def edit
@@ -24,13 +24,13 @@ class IncidentsController < ApplicationController
   def update
     incident = Incident.find(params[:id])
     incident.update!(incident_params)
-    redirect_to incident
+    redirect_to incident, notice: "更新しました"
   end
 
   def destroy
     incident = Incident.find(params[:id])
     incident.destroy!
-    redirect_to root_path
+    redirect_to root_path, alert: "削除しました"
   end
 
   private

--- a/app/views/incidents/_form.html.erb
+++ b/app/views/incidents/_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_with model: incident, local: true do |form| %>
+  <div class="form-group">
+    <%= form.label :incident, "事象" %>
+    <%= form.text_field :incident, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= form.label :solution, "解決方法" %>
+    <%= form.text_area :solution, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= form.submit button_value, data: {confirm: "#{button_value}しますか？"}, class: "btn btn-primary new-page-btn"%>
+  </div>
+<% end %>
+  <%= link_to "戻る", :back, data: {confirm: "保存しないで戻ります。よろしいですか？"}, class: "btn btn-secondary new-page-btn" %>

--- a/app/views/incidents/edit.html.erb
+++ b/app/views/incidents/edit.html.erb
@@ -1,2 +1,17 @@
-<h1>Incidents#edit</h1>
-<p>Find me in app/views/incidents/edit.html.erb</p>
+<h2 class="page-title">更新画面</h2>
+<h2 class="border-bottom border-dark">No.<%= sprintf("%008d", @incident.id) %></h2>
+
+<%= form_with model: @incident, local: true do |form| %>
+  <div class="form-group">
+    <%= form.label :incident, "事象" %>
+    <%= form.text_field :incident, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= form.label :solution, "解決方法" %>
+    <%= form.text_area :solution, class: "form-control" %>
+  </div>
+  <div class="form-group">
+    <%= form.submit "更新", data: {confirm: "更新しますか？"}, class: "btn btn-primary new-page-btn"%>
+  </div>
+<% end %>
+  <%= link_to "戻る", :back, data: {confirm: "保存しないで戻ります。よろしいですか？"}, class: "btn btn-secondary new-page-btn" %>

--- a/app/views/incidents/edit.html.erb
+++ b/app/views/incidents/edit.html.erb
@@ -1,17 +1,3 @@
 <h2 class="page-title">更新画面</h2>
 <h2 class="border-bottom border-dark">No.<%= sprintf("%008d", @incident.id) %></h2>
-
-<%= form_with model: @incident, local: true do |form| %>
-  <div class="form-group">
-    <%= form.label :incident, "事象" %>
-    <%= form.text_field :incident, class: "form-control" %>
-  </div>
-  <div class="form-group">
-    <%= form.label :solution, "解決方法" %>
-    <%= form.text_area :solution, class: "form-control" %>
-  </div>
-  <div class="form-group">
-    <%= form.submit "更新", data: {confirm: "更新しますか？"}, class: "btn btn-primary new-page-btn"%>
-  </div>
-<% end %>
-  <%= link_to "戻る", :back, data: {confirm: "保存しないで戻ります。よろしいですか？"}, class: "btn btn-secondary new-page-btn" %>
+<%= render partial: "form", locals: { incident: @incident, button_value: "更新" } %>

--- a/app/views/incidents/new.html.erb
+++ b/app/views/incidents/new.html.erb
@@ -1,16 +1,3 @@
 <h2 class="page-title">新規発行</h2>
+<%= render partial: "form", locals: { incident: @incident,button_value: "発行" } %>
 
-<%= form_with model: @incident, local: true do |form| %>
-  <div class="form-group">
-    <%= form.label :incident, "事象" %>
-    <%= form.text_field :incident, class: "form-control" %>
-  </div>
-  <div class="form-group">
-    <%= form.label :solution, "解決方法" %>
-    <%= form.text_area :solution, class: "form-control" %>
-  </div>
-  <div class="form-group">
-    <%= form.submit "発行", data: {confirm: "発行しますか？"}, class: "btn btn-primary new-page-btn"%>
-  </div>
-<% end %>
-  <%= link_to "戻る", :back, data: {confirm: "保存しないで戻ります。よろしいですか？"}, class: "btn btn-secondary new-page-btn" %>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,8 +1,10 @@
 <h2 class="page-title">参照</h2>
-<h2 class="border-bottom border-dark">No.<%= sprintf("%008d", @incident.id) %></h2>
-<div class="update-buttom">
-  <%= link_to "更新", edit_incident_path %>
-  <%= link_to "削除", @incident, method: :delete, data: { confirm: "削除しますか?" } %>
+<div class="show-header">
+  <h2 class="border-bottom border-dark">No.<%= sprintf("%008d", @incident.id) %></h2>
+  <div class="update-buttom">
+    <%= link_to "更新", edit_incident_path, class: "btn btn-primary"%>
+    <%= link_to "削除", @incident, method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-primary" %>
+  </div>
 </div>
 <div class="show-created-time row">
   <p class="col-2">作成日時</p>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,4 +1,4 @@
-<h1>参照</h1>
+<h2 class="page-title">参照</h2>
 <h2 class="border-bottom border-dark">No.<%= sprintf("%008d", @incident.id) %></h2>
 <div class="update-buttom">
   <%= link_to "更新", edit_incident_path %>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,5 +1,9 @@
 <h1>参照</h1>
 <h2 class="border-bottom border-dark">No.<%= sprintf("%008d", @incident.id) %></h2>
+<div class="update-buttom">
+  <%= link_to "更新", edit_incident_path %>
+  <%= link_to "削除", @incident, method: :delete, data: { confirm: "削除しますか?" } %>
+</div>
 <div class="show-created-time row">
   <p class="col-2">作成日時</p>
   <p class="col-10"><%= l @incident.created_at, format: :default %></p>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,6 +1,6 @@
 <h2 class="page-title">参照</h2>
-<div class="show-header">
-  <h2 class="border-bottom border-dark">No.<%= sprintf("%008d", @incident.id) %></h2>
+<div class="show-header border-bottom border-dark">
+  <h2>No.<%= sprintf("%008d", @incident.id) %></h2>
   <div class="update-buttom">
     <%= link_to "更新", edit_incident_path, class: "btn btn-primary"%>
     <%= link_to "削除", @incident, method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-primary" %>


### PR DESCRIPTION
## issue 番号

close #18 

## 実装内容

- 発行ボタン
　- 発行するか確認のポップアップを表示

- 戻るボタン
　- 本当に戻るか確認
　- 戻る場合は入力をキャンセルして戻る

- 入力フォーム
　- 事象入力
　- 解決方法入力

- 参照画面に編集ボタンの追加

※記事入力画面は別タスクとする
## 参考資料

- [メッセージ投稿アプリ（その2・エラー処理）](https://www.yanbaru-code.com/texts/270)
- [CSSで横並びレイアウトを実現簡単にするinline-blockとは？](https://www.sejuku.net/blog/52822)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）

## 備考（必要があれば）
