### PR TITLE
パスワードリセット機能を追加

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+GOOGLE_MAIL_ADDRESS = 'koyoi561@gamil.com'
+GOOGLE_MAILER_PASSWORD = 'unhpusokoeemjqve'

--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-GOOGLE_MAIL_ADDRESS = 'koyoi561@gamil.com'
-GOOGLE_MAILER_PASSWORD = 'unhpusokoeemjqve'
+GOOGLE_MAIL_ADDRESS = 'koyoi561@gmail.com'
+GOOGLE_MAILER_PASSWORD = 'jroaosjpixlsrhkf'

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 GOOGLE_MAIL_ADDRESS = 'koyoi561@gmail.com'
 GOOGLE_MAILER_PASSWORD = 'jroaosjpixlsrhkf'
-HOST_NAME = 'localhost'
+HOST = 'localhost'

--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 GOOGLE_MAIL_ADDRESS = 'koyoi561@gmail.com'
 GOOGLE_MAILER_PASSWORD = 'jroaosjpixlsrhkf'
+HOST_NAME = 'localhost'

--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-GOOGLE_MAIL_ADDRESS = 'koyoi561@gmail.com'
-GOOGLE_MAILER_PASSWORD = 'jroaosjpixlsrhkf'
-HOST = 'localhost'

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ yarn-debug.log*
 .yarn-integrity
 .DS_Store
 /vendor/bundle
-.env
+/.env

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-debug.log*
 .yarn-integrity
 .DS_Store
 /vendor/bundle
+/.env

--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ yarn-debug.log*
 .yarn-integrity
 .DS_Store
 /vendor/bundle
-/.env
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -48,12 +48,13 @@ gem "ransack"
 gem "kaminari"
 
 # 管理者画面
-gem 'activeadmin'
+gem "activeadmin"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "pry-byebug"
+  gem "dotenv-rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
     devise-bootstrap-views (1.1.0)
     devise-i18n (1.9.2)
       devise (>= 4.7.1)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     faker (2.18.0)
       i18n (>= 1.6, < 2)
@@ -260,6 +264,7 @@ DEPENDENCIES
   devise
   devise-bootstrap-views (~> 1.0)
   devise-i18n
+  dotenv-rails
   faker
   i18n_generators
   jbuilder (~> 2.7)

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p><%= t('.greeting', recipient: @resource.email) %></p>
+<p><%= t(".greeting", recipient: @resource.email) %></p>
 
-<p><%= t('.instruction') %></p>
+<p><%= t(".instruction") %></p>
 
-<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t(".action"), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p><%= t('.instruction_2') %></p>
-<p><%= t('.instruction_3') %></p>
+<p><%= t(".instruction_2") %></p>
+<p><%= t(".instruction_3") %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,8 +86,8 @@ Rails.application.configure do
     :address => "smtp.gmail.com",
     :port => 587,
     :domain => 'smtp.gmail.com',
-    :user_name => "koyoi561@gmail.com",
-    :password => "unhpusokoeemjqve",
+    :user_name => ENV["GOOGLE_MAIL_ADDRESS"],
+    :password => ENV["GOOGLE_MAILER_PASSWORD"],
     :authentication => 'login'
   }
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,9 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # mailer setting
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
 
   # mailer setting
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-  
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
@@ -76,4 +76,18 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.action_mailer.perform_caching = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :enable_starttls_auto => true,
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :domain => 'smtp.gmail.com',
+    :user_name => ENV["GOOGLE_MAIL_ADDRESS"],
+    :password => ENV["GOOGLE_MAILER_PASSWORD"],
+    :authentication => 'login'
+  }
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: HOST_NAME, port: 3000 }
+  config.action_mailer.default_url_options = { host: ENV["HOST_NAME"], port: 3000 }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     :enable_starttls_auto => true,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,14 +33,6 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.perform_caching = false
-
-  # mailer setting
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
@@ -79,7 +71,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: HOST_NAME, port: 3000 }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     :enable_starttls_auto => true,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,8 +86,8 @@ Rails.application.configure do
     :address => "smtp.gmail.com",
     :port => 587,
     :domain => 'smtp.gmail.com',
-    :user_name => ENV["GOOGLE_MAIL_ADDRESS"],
-    :password => ENV["GOOGLE_MAILER_PASSWORD"],
+    :user_name => "koyoi561@gmail.com",
+    :password => "unhpusokoeemjqve",
     :authentication => 'login'
   }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -118,7 +118,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: HOST_NAME }
+  config.action_mailer.default_url_options = { host: ENV["HOST_NAME"] }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     :enable_starttls_auto => true,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -117,4 +117,17 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+  config.action_mailer.perform_caching = true
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { host: "incident-app-20210526-staging.herokuapp.com" }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :enable_starttls_auto => true,
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :domain => 'smtp.gmail.com',
+    :user_name => ENV["GOOGLE_MAIL_ADDRESS"],
+    :password => ENV["GOOGLE_MAILER_PASSWORD"],
+    :authentication => 'login'
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,8 +62,6 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "incident_app_production"
 
-  config.action_mailer.perform_caching = false
-
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
@@ -117,9 +115,10 @@ Rails.application.configure do
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
+
   config.action_mailer.perform_caching = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.default_url_options = { host: "incident-app-20210526-staging.herokuapp.com" }
+  config.action_mailer.default_url_options = { host: HOST_NAME }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     :enable_starttls_auto => true,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV["GOOGLE_MAIL_ADDRESS"]
+  config.mailer_sender = "koyoi561@gmail.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV["GOOGLE_MAIL_ADDRESS"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -218,17 +218,16 @@ Devise.setup do |config|
 
   # ==> Configuration for :recoverable
   #
-  # Defines which key will be used when recovering the password for an account
-  # config.reset_password_keys = [:email]
+  # アカウントのパスワードを回復するときに使用するキー
+  config.reset_password_keys = [:email]
 
-  # Time interval you can reset your password with a reset password key.
-  # Don't put a too small interval or your users won't have the time to
-  # change their passwords.
+  #リセットパスワードキーを使ってパスワードをリセットできる時間間隔
   config.reset_password_within = 6.hours
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.
-  # config.sign_in_after_reset_password = true
+  #パスワードが設定された後、ユーザーが自動的にサインインする
+  config.sign_in_after_reset_password = true
 
   # ==> Configuration for :encryptable
   # Allow you to use another hashing or encryption algorithm besides bcrypt (default).

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "koyoi561@gmail.com"
+  config.mailer_sender = ENV["GOOGLE_MAIL_ADDRESS"]
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
## issue 番号

close #26 

## 実装内容

- パスワードリセットメール送信機能を追加
- 環境変数にて、メールアドレスとパスワードを設定

## 参考資料

- [Devise入門 64のレシピ](https://nekorails.hatenablog.com/entry/2021/03/18/110200)
- [【Rails】 deviseの使い方をマスターしてログイン認証機能を実装しよう！](https://pikawaka.com/rails/devise)
- [devise公式-Module: Devise::Models::Recoverable](https://rubydoc.info/github/heartcombo/devise/master/Devise/Models/Recoverable)
## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

