### PR TITLE
表示画面の修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -109,9 +109,13 @@ main{
   }
 }
 .title,.contents,.articles{
-  margin: 0px 0px 1em 0px;
+  margin: 0px 0px 5px 0px;
 }
-
+.title{
+  h2{
+    margin-bottom: 0px;
+  }
+}
 
 
 // 576pxまではテーブル表示中止

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -97,9 +97,6 @@ main{
 
 
 // show
-.article-new-btn,.update-button {
-  text-align: right;
-}
 .field_with_errors {
   display: contents;
   label {
@@ -118,8 +115,18 @@ main{
 .show-label{
   text-align: center;
 }
-.article-form{
-  padding: 10px;
+.articles{
+  padding-top: 20px;
+  .article-form{
+    padding: 10px;
+  }
+  .articels-form-group {
+    margin: 0px 15px 20px 15px;
+  }
+  .article-new-btn,.update-button {
+    text-align: right;
+    margin-top: 10px;
+  }
 }
 
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -123,7 +123,7 @@ main{
     display: none;
   }
   table tr {
-    margin-bottom: 10px;
+    margin: 7px ;
     display: block;
     border: 2px solid #ddd;
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -108,7 +108,7 @@ main{
     font: bold;
   }
 }
-.show-header,.show-contents,.show-articles{
+.title,.contents,.articles{
   margin: 0px 0px 1em 0px;
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -104,6 +104,11 @@ main{
     font: bold;
   }
 }
+.title{
+  .update-button {
+    text-align: right;
+  }
+}
 .title,.contents,.articles{
   margin: 0px 0px 5px 0px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -72,7 +72,7 @@ main{
 }
 
 .form-group{
-  margin: 5px auto;
+  margin: 10px auto;
 }
 
 
@@ -149,3 +149,9 @@ main{
   }
 
 }
+
+// search_form
+.col-form-label{
+  font-size: large;
+}
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -119,6 +119,9 @@ main{
 .show-label{
   text-align: center;
 }
+.article-form{
+  padding: 10px;
+}
 
 
 // 576pxまではテーブル表示中止

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -116,6 +116,9 @@ main{
     margin-bottom: 0px;
   }
 }
+.show-label{
+  text-align: center;
+}
 
 
 // 576pxまではテーブル表示中止

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -97,8 +97,7 @@ main{
 
 
 // show
-.new-button,.update-button{
-  display: inline-block;
+.article-new-btn,.update-button {
   text-align: right;
 }
 .field_with_errors {

--- a/app/views/incidents/_list.html.erb
+++ b/app/views/incidents/_list.html.erb
@@ -1,4 +1,4 @@
-<div >
+<div class="list">
   <table class="table event_table">
     <thead class="thead-light">
       <tr>

--- a/app/views/incidents/_pagenation.html.erb
+++ b/app/views/incidents/_pagenation.html.erb
@@ -1,4 +1,6 @@
-<%= paginate incidents %>
-<div class="d-flex justify-content-end">
-  <%= page_entries_info incidents %>
+<div class="pagenation">
+  <%= paginate incidents %>
+  <div class="d-flex justify-content-end">
+    <%= page_entries_info incidents %>
+  </div>
 </div>

--- a/app/views/incidents/_search_form.html.erb
+++ b/app/views/incidents/_search_form.html.erb
@@ -1,26 +1,26 @@
 <div class="search_form">
   <%= search_form_for q, url: search_incidents_path do |f| %>
     <div class="form-group row">
-      <%= f.label :incident_has_every_term, "事象", class: "col-sm-2 col-form-label" %>
-      <div class="col-sm-10">
+      <%= f.label :incident_has_every_term, "事象", class: "col-2 col-form-label" %>
+      <div class="col-10">
         <%= f.search_field :incident_has_every_term, class: "form-control" %>
       </div>
     </div>
     <div class="form-group row">
-      <%= f.label :os_name_name_eq, "OS", class: "col-sm-2 col-form-label" %>
-      <div class="col-sm-10">
+      <%= f.label :os_name_name_eq, "OS", class: "col-2 col-form-label" %>
+      <div class="col-10">
         <%= f.select :os_name_name_eq, OsName.all.collect { |os| [os.name, os.name] }, { prompt: "OSを選択してください" }, { class: "form-control form-control-sm" } %> 
       </div>
     </div>
     <div class="form-group row">
-      <%= f.label :coding_lang_name_eq, "言語", class: "col-sm-2 col-form-label" %>
-      <div class="col-sm-10">
+      <%= f.label :coding_lang_name_eq, "言語", class: "col-2 col-form-label" %>
+      <div class="col-10">
         <%= f.select :coding_lang_name_eq, CodingLang.all.collect { |coding_lang| [coding_lang.name, coding_lang.name] }, { prompt: "言語を選択してください" }, { class: "form-control form-control-sm" } %>
       </div>
     </div>
     <div class="form-group row">
-      <%= f.label :status_status_eq, "状態", class: "col-sm-2 col-form-label" %>
-      <div class="col-sm-10">
+      <%= f.label :status_status_eq, "状態", class: "col-2 col-form-label" %>
+      <div class="col-10">
         <%= f.select :status_status_eq, Status.all.collect { |status| [status.status, status.status] }, { prompt: "状態を選択してください" }, { class: "form-control form-control-sm" } %>
       </div>
     </div>

--- a/app/views/incidents/_search_form.html.erb
+++ b/app/views/incidents/_search_form.html.erb
@@ -1,32 +1,33 @@
-<h1>検索</h1>
-<%= search_form_for q, url: search_incidents_path do |f| %>
-  <div class="form-group row">
-    <%= f.label :incident_has_every_term, "事象", class: "col-sm-2 col-form-label" %>
-    <div class="col-sm-10">
-      <%= f.search_field :incident_has_every_term, class: "form-control" %>
+<div class="search_form">
+  <%= search_form_for q, url: search_incidents_path do |f| %>
+    <div class="form-group row">
+      <%= f.label :incident_has_every_term, "事象", class: "col-sm-2 col-form-label" %>
+      <div class="col-sm-10">
+        <%= f.search_field :incident_has_every_term, class: "form-control" %>
+      </div>
     </div>
-  </div>
-  <div class="form-group row">
-    <%= f.label :os_name_name_eq, "OS", class: "col-sm-2 col-form-label" %>
-    <div class="col-sm-10">
-      <%= f.select :os_name_name_eq, OsName.all.collect { |os| [os.name, os.name] }, { prompt: "OSを選択してください" }, { class: "form-control form-control-sm" } %> 
+    <div class="form-group row">
+      <%= f.label :os_name_name_eq, "OS", class: "col-sm-2 col-form-label" %>
+      <div class="col-sm-10">
+        <%= f.select :os_name_name_eq, OsName.all.collect { |os| [os.name, os.name] }, { prompt: "OSを選択してください" }, { class: "form-control form-control-sm" } %> 
+      </div>
     </div>
-  </div>
-  <div class="form-group row">
-    <%= f.label :coding_lang_name_eq, "言語", class: "col-sm-2 col-form-label" %>
-    <div class="col-sm-10">
-      <%= f.select :coding_lang_name_eq, CodingLang.all.collect { |coding_lang| [coding_lang.name, coding_lang.name] }, { prompt: "言語を選択してください" }, { class: "form-control form-control-sm" } %>
+    <div class="form-group row">
+      <%= f.label :coding_lang_name_eq, "言語", class: "col-sm-2 col-form-label" %>
+      <div class="col-sm-10">
+        <%= f.select :coding_lang_name_eq, CodingLang.all.collect { |coding_lang| [coding_lang.name, coding_lang.name] }, { prompt: "言語を選択してください" }, { class: "form-control form-control-sm" } %>
+      </div>
     </div>
-  </div>
-  <div class="form-group row">
-    <%= f.label :status_status_eq, "状態", class: "col-sm-2 col-form-label" %>
-    <div class="col-sm-10">
-      <%= f.select :status_status_eq, Status.all.collect { |status| [status.status, status.status] }, { prompt: "状態を選択してください" }, { class: "form-control form-control-sm" } %>
+    <div class="form-group row">
+      <%= f.label :status_status_eq, "状態", class: "col-sm-2 col-form-label" %>
+      <div class="col-sm-10">
+        <%= f.select :status_status_eq, Status.all.collect { |status| [status.status, status.status] }, { prompt: "状態を選択してください" }, { class: "form-control form-control-sm" } %>
+      </div>
     </div>
-  </div>
 
-  <div class="form-group">
-    <%= f.submit '検索', class: "btn btn-primary page-btn" %>
-  </div>
-<% end %>
+    <div class="form-group">
+      <%= f.submit '検索', class: "btn btn-primary page-btn" %>
+    </div>
+  <% end %>
+</div>
 <hr>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -58,11 +58,16 @@
   </div>
   <div class="articles-contents">
     <% @articles.each_with_index do |article| %>
-      <div class="articles-contents-top">
+      <div class="articles-contents-top row">
         <div class="col">
           <%= article.user.email %>
         </div>
+        
         <div class="update-button col">
+          作成日時：<%= l article.created_at, format: :long %>
+          <% if article.created_at < article.updated_at %>
+            更新済み
+          <% end %>
           <% if current_user.id == article.user_id %>
               <%= link_to "更新", edit_incident_article_path(@incident, article), class: "btn btn-primary"%> 
               <%= link_to "削除", incident_article_path(@incident, article), method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-primary"%>
@@ -70,15 +75,6 @@
         </div>
       </div>
       <div class="articles-contents-bottom">
-        <div class="show-created-time row">
-          <div class="col-sm-2">作成日時</div>
-          <div class="col-sm-10"><%= l article.created_at, format: :long %></div>
-        </div>
-
-        <div class="show-updated-time row">
-          <div class="col-sm-2">更新日時</div>
-          <div class="col-sm-10"><%= l article.updated_at, format: :long %></div>
-        </div>
         <div class="show-article ">
             <%= safe_join(article.content.split("\n"), tag(:br)) %>
         </div>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -10,39 +10,35 @@
 </div>
 <div class="contents bg-light row border-bottom">
   <div class="row incident">
-    <p class="col-3">事象</p>
+    <p class="col-3 show-label">事象</p>
     <p class = "col-9"><%= @incident.incident %></p>
   </div>
-
   <div class="row solution">
-    <p class="col-3">解決方法</p>
+    <p class="col-3 show-label">解決方法</p>
     <p class = "col-9"><%= safe_join(@incident.solution.split("\n"), tag(:br)) %></p>
   </div>
   <div class="Email row">
-    <p class="col-3">Email</p>
+    <p class="col-3 show-label">Email</p>
     <p class = "col-9"><%= @incident.user.email %></p>
   </div>
   <div class="row create_at">
-    <p class="col-3">作成日時</p>
+    <p class="col-3 show-label">作成日時</p>
     <p class="col-9"><%= l @incident.created_at, format: :long %></p>
   </div>
   <div class="row updated_at">
-    <p class="col-3">更新日時</p>
+    <p class="col-3 show-label">更新日時</p>
     <p class="col-9"><%= l @incident.updated_at, format: :long %></p>
   </div>
-
-
   <div class="row status">
-    <p class="col-3">ステータス</p>
+    <p class="col-3 show-label">ステータス</p>
     <p class = "col-9"><%= @incident.status.status%></p>
   </div>
-
   <div class="row os">
-    <p class="col-3">OS</p>
+    <p class="col-3 show-label">OS</p>
     <p class = "col-9"><%= @incident.os_name.name %></p>
   </div>
   <div class="row coding_lang">
-    <p class="col-3">言語</p>
+    <p class="col-3 show-label">言語</p>
     <p class = "col-9"><%= @incident.coding_lang.name %></p>
   </div>
 </div>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -43,39 +43,46 @@
   </div>
 </div>
 <div class="articles bg-light row">
-  <h4 class="col-sm-2">記事</h4>
-  <%= form_with model: [@incident, @article] do |form| %>
-    <div class="form-group row">
-      <div>
-        <%= form.text_area :content, class: "form-control" %>    
+  <div class="articels-form">
+    <h4>アカウント名</h4>
+    <%= form_with model: [@incident, @article] do |form| %>
+      <div class="form-group row">
+        <div>
+          <%= form.text_area :content, class: "form-control" %>    
+        </div>
+        <div class="new-button">
+          <%= form.submit "発行", data: {confirm: "記事を作成しますか？"}, class: "btn btn-primary"%>
+        </div>   
       </div>
-      <div class="new-button">
-        <%= form.submit "発行", data: {confirm: "記事を作成しますか？"}, class: "btn btn-primary"%>
-      </div>   
-    </div>
-  <% end %>
-  <hr>
-  <% @articles.each_with_index do |article| %>
-    <div class="col-2">
-      <%= article.user.email %>
-    </div>
-    <div class="update-button col-10">
-      <% if current_user.id == article.user_id %>
-          <%= link_to "更新", edit_incident_article_path(@incident, article), class: "btn btn-primary"%> 
-          <%= link_to "削除", incident_article_path(@incident, article), method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-primary"%>
-      <% end %>
-    </div>
-  <div class="show-created-time row">
-    <div class="col-sm-2">作成日時</div>
-    <div class="col-sm-10"><%= l article.created_at, format: :long %></div>
+    <% end %>
   </div>
+  <div class="articles-contents">
+    <% @articles.each_with_index do |article| %>
+      <div class="articles-contents-top">
+        <div class="col">
+          <%= article.user.email %>
+        </div>
+        <div class="update-button col">
+          <% if current_user.id == article.user_id %>
+              <%= link_to "更新", edit_incident_article_path(@incident, article), class: "btn btn-primary"%> 
+              <%= link_to "削除", incident_article_path(@incident, article), method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-primary"%>
+          <% end %>
+        </div>
+      </div>
+      <div class="articles-contents-bottom">
+        <div class="show-created-time row">
+          <div class="col-sm-2">作成日時</div>
+          <div class="col-sm-10"><%= l article.created_at, format: :long %></div>
+        </div>
 
-  <div class="show-updated-time row">
-    <div class="col-sm-2">更新日時</div>
-    <div class="col-sm-10"><%= l article.updated_at, format: :long %></div>
+        <div class="show-updated-time row">
+          <div class="col-sm-2">更新日時</div>
+          <div class="col-sm-10"><%= l article.updated_at, format: :long %></div>
+        </div>
+        <div class="show-article ">
+            <%= safe_join(article.content.split("\n"), tag(:br)) %>
+        </div>
+      </div>
+    <% end %>
   </div>
-  <div class="show-article ">
-      <%= safe_join(article.content.split("\n"), tag(:br)) %>
-  </div>
-  <% end %>
 </div>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -50,7 +50,7 @@
         <div>
           <%= form.text_area :content, class: "form-control" %>    
         </div>
-        <div>
+        <div class="article-new-btn">
           <%= form.submit "発行", data: {confirm: "記事を作成しますか？"}, class: "btn btn-primary"%>
         </div>   
         </div>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -1,4 +1,4 @@
-<div class="show-header bg-light row border-bottom">
+<div class="title bg-light row border-bottom">
   <h2 class="show-title col">No.<%= sprintf("%008d", @incident.id) %></h2>
   <div class="update-button col ">
     <% if current_user.id == @incident.user_id %>
@@ -7,7 +7,7 @@
     <% end %>
   </div>
 </div>
-<div class="show-contents bg-light row border-bottom">
+<div class="contents bg-light row border-bottom">
   <div class="Email row">
     <p class="col-sm-2">Email</p>
     <p class = "border col-sm-10"><%= @incident.user.email %></p>
@@ -45,7 +45,7 @@
     <p class = "border bg-light col-sm-10"><%= @incident.coding_lang.name %></p>
   </div>
 </div>
-<div class="show-articles bg-light row">
+<div class="articles bg-light row">
   <h4 class="col-sm-2">記事</h4>
   <%= form_with model: [@incident, @article] do |form| %>
     <div class="form-group row">

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -62,7 +62,6 @@
         <div class="col">
           <%= article.user.email %>
         </div>
-        
         <div class="update-button col">
           作成日時：<%= l article.created_at, format: :long %>
           <% if article.created_at < article.updated_at %>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -9,11 +9,20 @@
   </div>
 </div>
 <div class="contents bg-light row border-bottom">
+  <div class="row incident">
+    <p class="col-sm-2">事象</p>
+    <p class = " bg-light col-sm-10"><%= @incident.incident %></p>
+  </div>
+
+  <div class="row solution">
+    <p class="col-sm-2">解決方法</p>
+    <p class = " bg-light col-sm-10"><%= safe_join(@incident.solution.split("\n"), tag(:br)) %></p>
+  </div>
   <div class="Email row">
     <p class="col-sm-2">Email</p>
-    <p class = "border col-sm-10"><%= @incident.user.email %></p>
+    <p class = " col-sm-10"><%= @incident.user.email %></p>
   </div>
-  <div class="row create_at" id="">
+  <div class="row create_at">
     <p class="col-sm-2">作成日時</p>
     <p class="col-sm-10"><%= l @incident.created_at, format: :default %></p>
   </div>
@@ -22,28 +31,19 @@
     <p class="col-sm-10"><%= l @incident.updated_at, format: :default %></p>
   </div>
 
-  <div class="row incident">
-    <p class="col-sm-2">事象</p>
-    <p class = "border bg-light col-sm-10"><%= @incident.incident %></p>
-  </div>
-
-  <div class="row solution">
-    <p class="col-sm-2">解決方法</p>
-    <p class = "border bg-light col-sm-10"><%= safe_join(@incident.solution.split("\n"), tag(:br)) %></p>
-  </div>
 
   <div class="row status">
     <p class="col-sm-2">ステータス</p>
-    <p class = "border bg-light col-sm-10"><%= @incident.status.status%></p>
+    <p class = " bg-light col-sm-10"><%= @incident.status.status%></p>
   </div>
 
   <div class="row os">
     <p class="col-sm-2">OS</p>
-    <p class = "border bg-light col-sm-10"><%= @incident.os_name.name %></p>
+    <p class = " bg-light col-sm-10"><%= @incident.os_name.name %></p>
   </div>
   <div class="row coding_lang">
     <p class="col-sm-2">言語</p>
-    <p class = "border bg-light col-sm-10"><%= @incident.coding_lang.name %></p>
+    <p class = " bg-light col-sm-10"><%= @incident.coding_lang.name %></p>
   </div>
 </div>
 <div class="articles bg-light row">
@@ -78,7 +78,7 @@
     <div class="col-sm-2">更新日時</div>
     <div class="col-sm-10"><%= l article.updated_at, format: :default %></div>
   </div>
-  <div class="show-article border">
+  <div class="show-article ">
       <%= safe_join(article.content.split("\n"), tag(:br)) %>
   </div>
   <% end %>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -44,17 +44,18 @@
 </div>
 <div class="articles bg-light row">
   <div class="articels-form">
-    <h4>アカウント名</h4>
-    <%= form_with model: [@incident, @article] do |form| %>
-      <div class="form-group row">
+    <h4 class="account-name">アカウント名</h4>
+    <div class="article-form border">
+      <%= form_with model: [@incident, @article] do |form| %>
         <div>
           <%= form.text_area :content, class: "form-control" %>    
         </div>
-        <div class="new-button">
+        <div>
           <%= form.submit "発行", data: {confirm: "記事を作成しますか？"}, class: "btn btn-primary"%>
         </div>   
-      </div>
-    <% end %>
+        </div>
+      <% end %>
+    </div>
   </div>
   <div class="articles-contents">
     <% @articles.each_with_index do |article| %>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -10,40 +10,40 @@
 </div>
 <div class="contents bg-light row border-bottom">
   <div class="row incident">
-    <p class="col-sm-2">事象</p>
-    <p class = " bg-light col-sm-10"><%= @incident.incident %></p>
+    <p class="col-3">事象</p>
+    <p class = "col-9"><%= @incident.incident %></p>
   </div>
 
   <div class="row solution">
-    <p class="col-sm-2">解決方法</p>
-    <p class = " bg-light col-sm-10"><%= safe_join(@incident.solution.split("\n"), tag(:br)) %></p>
+    <p class="col-3">解決方法</p>
+    <p class = "col-9"><%= safe_join(@incident.solution.split("\n"), tag(:br)) %></p>
   </div>
   <div class="Email row">
-    <p class="col-sm-2">Email</p>
-    <p class = " col-sm-10"><%= @incident.user.email %></p>
+    <p class="col-3">Email</p>
+    <p class = "col-9"><%= @incident.user.email %></p>
   </div>
   <div class="row create_at">
-    <p class="col-sm-2">作成日時</p>
-    <p class="col-sm-10"><%= l @incident.created_at, format: :long %></p>
+    <p class="col-3">作成日時</p>
+    <p class="col-9"><%= l @incident.created_at, format: :long %></p>
   </div>
   <div class="row updated_at">
-    <p class="col-sm-2">更新日時</p>
-    <p class="col-sm-10"><%= l @incident.updated_at, format: :long %></p>
+    <p class="col-3">更新日時</p>
+    <p class="col-9"><%= l @incident.updated_at, format: :long %></p>
   </div>
 
 
   <div class="row status">
-    <p class="col-sm-2">ステータス</p>
-    <p class = " bg-light col-sm-10"><%= @incident.status.status%></p>
+    <p class="col-3">ステータス</p>
+    <p class = "col-9"><%= @incident.status.status%></p>
   </div>
 
   <div class="row os">
-    <p class="col-sm-2">OS</p>
-    <p class = " bg-light col-sm-10"><%= @incident.os_name.name %></p>
+    <p class="col-3">OS</p>
+    <p class = "col-9"><%= @incident.os_name.name %></p>
   </div>
   <div class="row coding_lang">
-    <p class="col-sm-2">言語</p>
-    <p class = " bg-light col-sm-10"><%= @incident.coding_lang.name %></p>
+    <p class="col-3">言語</p>
+    <p class = "col-9"><%= @incident.coding_lang.name %></p>
   </div>
 </div>
 <div class="articles bg-light row">

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -24,11 +24,11 @@
   </div>
   <div class="row create_at">
     <p class="col-sm-2">作成日時</p>
-    <p class="col-sm-10"><%= l @incident.created_at, format: :default %></p>
+    <p class="col-sm-10"><%= l @incident.created_at, format: :long %></p>
   </div>
   <div class="row updated_at">
     <p class="col-sm-2">更新日時</p>
-    <p class="col-sm-10"><%= l @incident.updated_at, format: :default %></p>
+    <p class="col-sm-10"><%= l @incident.updated_at, format: :long %></p>
   </div>
 
 
@@ -71,12 +71,12 @@
     </div>
   <div class="show-created-time row">
     <div class="col-sm-2">作成日時</div>
-    <div class="col-sm-10"><%= l article.created_at, format: :default %></div>
+    <div class="col-sm-10"><%= l article.created_at, format: :long %></div>
   </div>
 
   <div class="show-updated-time row">
     <div class="col-sm-2">更新日時</div>
-    <div class="col-sm-10"><%= l article.updated_at, format: :default %></div>
+    <div class="col-sm-10"><%= l article.updated_at, format: :long %></div>
   </div>
   <div class="show-article ">
       <%= safe_join(article.content.split("\n"), tag(:br)) %>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -42,8 +42,8 @@
     <p class = "col-9"><%= @incident.coding_lang.name %></p>
   </div>
 </div>
-<div class="articles bg-light row">
-  <div class="articels-form">
+<div class="articles bg-light">
+  <div class="articels-form-group">
     <h4 class="account-name">アカウント名</h4>
     <div class="article-form border">
       <%= form_with model: [@incident, @article] do |form| %>
@@ -53,7 +53,6 @@
         <div class="article-new-btn">
           <%= form.submit "発行", data: {confirm: "記事を作成しますか？"}, class: "btn btn-primary"%>
         </div>   
-        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/incidents/show.html.erb
+++ b/app/views/incidents/show.html.erb
@@ -5,6 +5,7 @@
         <%= link_to "更新", edit_incident_path, class: "btn btn-primary"%>
         <%= link_to "削除", @incident, method: :delete, data: { confirm: "削除しますか?" }, class: "btn btn-primary" %>
     <% end %>
+    <%= link_to "戻る", :back, class: "btn btn-primary" %>
   </div>
 </div>
 <div class="contents bg-light row border-bottom">


### PR DESCRIPTION
## issue 番号

close #63

## 実装内容

- 構成の統一
    - クラス名を`title`と`contents`と`articles`　とする
    - `title` クラス
        - 横に戻るボタンを配置
        - ボタンとタイトルの下のマージンを整える
    - `contents`　クラス
        - 内容欄の外枠を外す
        - 事象、解決方法から、表示するよう変更
        - 時間の表示から、秒数を排除
        - ラベルに`show-label`クラスを付与
        - `show-label`を枠内中央寄せに
    - `articles`　クラス
        - クラスを`articels-form`と`articles-contents`とする
        - `articels-form`クラス
            - アカウント名、フォーム、ボタンという構成にする
        - `articles-contents`クラス
            - 構成を`articles-contents-top`と`articles-contents-bottom`とする
            - `articles-contents-top`クラスにはアドレス、更新ボタン、削除ボタン、作成日時を配置する。更新された際は、更新済みの文字表示
            - `articles-contents-bottom`クラスは枠を削る
- モバイルのみ修正
    - `contents`　クラス
        - 横並びに表示するよう変更
    - `articles`　クラス

## 参考資料

## チェックリスト

- [x]  GitHub で Files changed を確認
- [x]  影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）

## 備考（必要があれば）

- 内容ごとの距離を詰める→デザインがおかしいのでやらない事とした

別issuesに繰越すもの

- `articles-contents-top`クラス更新された際は、更新済みの文字をアカウント名の下に表示
- 記事投稿欄のデザインの変更を詰める