### PR TITLE
ログイン機能変更及び画面修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,10 +1,14 @@
 @import "bootstrap/scss/bootstrap";
 
 /* 全体 */
+/* main */
+main {
+  margin-top: 56px;
+}
 
 .base-container {
-  margin: 56px auto 0px auto;
-  padding-top: 1em;
+  margin: 0px auto;
+  padding: 56px 5px 0px 5px;
 }
 
 /* max-width */
@@ -23,8 +27,6 @@
 .mw-xl {
   max-width: 1200px;
 }
-
-
 
 /* header */
 header a{
@@ -61,10 +63,7 @@ header{
   @extend .alert-danger;
 }
 
-/* main */
-main{
-  margin-top: 56px;
-}
+
 
 /* devise */
 .btn{

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    # サインアップ時にemail属性を許可する
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:email])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64
+      user.username = "ゲスト"
     end
   end
   validates :username, uniqueness: true, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,8 @@ class User < ApplicationRecord
   has_many :articled_incidents, through: :articles, source: :incident
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :authentication_keys => [:username], :registerable,
-         :recoverable, :rememberable, :validatable
+  devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable,
+         :authentication_keys => [:username]
   validates :username, uniqueness: true
   validates :email, uniqueness: true
   def self.guest

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64
-      user.username = "ゲスト"
+      user.username = "guest"
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,10 @@ class User < ApplicationRecord
   has_many :articled_incidents, through: :articles, source: :incident
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :authentication_keys => [:username], :registerable,
          :recoverable, :rememberable, :validatable
-  validates :username, uniqueness: true, presence: true
+  validates :username, uniqueness: true
+  validates :email, uniqueness: true
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,11 +6,11 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  validates :username, uniqueness: true, presence: true
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64
       user.username = "ゲスト"
     end
   end
-  validates :username, uniqueness: true, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,7 @@ class User < ApplicationRecord
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|
       user.password = SecureRandom.urlsafe_base64
-      # user.confirmed_at = Time.now  # Confirmable を使用している場合は必要
-      # 例えば name を入力必須としているならば， user.name = "ゲスト" なども必要
     end
   end
+  validates :username, uniqueness: true, presence: true
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -7,6 +7,11 @@
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
   </div>
+  
+  <div class="form-group">
+    <%= f.label :username %><br />
+    <%= f.text_field :username, autocomplete: "username", class: "form-control" %>
+  </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div><%= t(".currently_waiting_confirmation_for_email", email: resource.unconfirmed_email) %></div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -50,4 +50,4 @@
 
 <p><%= button_to t(".cancel_my_account"), registration_path(resource_name), data: { confirm: t(".are_you_sure") }, method: :delete, class: "btn btn-secondary btn-sm w-100" %></p>
 
-<%= link_to t("devise.shared.links.back"), :back %>
+<%= link_to t("devise.shared.links.back"), :back, class: "btn btn-primary btn-block w-100" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,7 +10,7 @@
   
   <div class="form-group">
     <%= f.label :username %><br />
-    <%= f.text_field :username, autocomplete: "username", class: "form-control" %>
+    <%= f.text_field :username, autofocus: true, autocomplete: "username", class: "form-control" %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="form-group">
     <%= f.label :username %><br />
-    <%= f.text_field :username, autocomplete: "username", class: "form-control" %>
+    <%= f.text_field :username, autofocus: true, autocomplete: "username", class: "form-control" %>
   </div>
   <div class="form-group">
     <%= f.label :password %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,7 +7,10 @@
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control" %>
   </div>
-
+  <div class="form-group">
+    <%= f.label :username %><br />
+    <%= f.text_field :username, autocomplete: "username", class: "form-control" %>
+  </div>
   <div class="form-group">
     <%= f.label :password %>
     <% if @minimum_password_length %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,22 +2,19 @@
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-group">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "form-control", placeholder: "Enter email" %>
+    <%= f.label :username %><br />
+    <%= f.text_field :username, autofocus: true, autocomplete: "username", class: "form-control", placeholder: "Enter username" %>
   </div>
-
   <div class="form-group">
     <%= f.label :password %><br />
     <%= f.password_field :password, autocomplete: "current-password", class: "form-control", placeholder: "Password" %>
   </div>
-
   <% if devise_mapping.rememberable? %>
     <div class="form-group">
       <%= f.check_box :remember_me, class: "form-check-input" %>
       <%= f.label :remember_me, class: "form-check-label" %>
     </div>
   <% end %>
-
   <div class="form-group ">
     <%= f.submit t(".sign_in"), class: "btn btn-primary btn-block w-100" %>
   </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -22,7 +22,7 @@
             <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
           </li>
           <li class="nav-item">
-            <%= "【ログイン中のアドレス】#{current_user.email}" %>
+            <%= "【ログイン中のアドレス】#{current_user.username}" %>
           </li>
         <% else %>
           <%# 非ログイン時 %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:username]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  config.authentication_keys = [:username]
+  # config.authentication_keys = [:email]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -10,6 +10,7 @@ ja:
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
         email: Eメール
+        username: ユーザ名
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻

--- a/db/migrate/20210903222350_add_username_to_users.rb
+++ b/db/migrate/20210903222350_add_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddUsernameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :username, :string
+    add_index :users, :username, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_13_041642) do
+ActiveRecord::Schema.define(version: 2021_09_03_222350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,8 +92,10 @@ ActiveRecord::Schema.define(version: 2021_07_13_041642) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "articles", "incidents"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,11 @@
 EMAIL = 'test@example.com'
+USERNAME = "testuser"
 PASSWORD = 'password'
 
 # テストユーザーが存在しないときだけ作成
 User.find_or_create_by!(email: EMAIL) do |user|
   user.password = PASSWORD
+  user.username = USERNAME
   puts 'ユーザーの初期データインポートに成功しました。'
 end
 #値の初期化
@@ -23,6 +25,8 @@ puts "インシデント初期データ投稿開始"
 1000.times do
   Incident.create!(incident: Faker::Quote.famous_last_words, solution: Faker::Quote.jack_handey, user_id: 1, os_name_id: OsName.find(rand(OsName.first.id..OsName.last.id)).id, status_id: Status.find(rand(Status.first.id..Status.last.id)).id, coding_lang_id: CodingLang.find(rand(CodingLang.first.id..CodingLang.last.id)).id)
 end
-
-AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password') 
+AdminUser.find_or_create_by!(email: 'admin@example.com') do |adminuser|
+  adminuser.password = PASSWORD 
+  adminuser.password_confirmation = PASSWORD
+end
 puts "初期データの投入に成功しました！"


### PR DESCRIPTION
## issue 番号

close #61

## 実装内容

- 全体的に横に余白を設けた
- ユーザ名でログインできるよう変更
- アカウント編集画面にてユーザ名を修正機能を実装
- 現在ログイン中の表示をユーザ名に変更
- ゲストログイン機能にて、ユーザ名が自動割当されるよう変更

## 参考資料

[[Rails]メールアドレス以外でサインインできるようにする[devise] ｜ もふもふ技術部](https://tech.mof-mof.co.jp/blog/devise-login-without-email/)

[Devise入門 64のレシピ - 猫Rails](https://nekorails.hatenablog.com/entry/2021/03/18/110200#024-email%E3%81%AE%E4%BB%A3%E3%82%8F%E3%82%8A%E3%81%ABusername%E3%81%A7%E3%83%AD%E3%82%B0%E3%82%A4%E3%83%B3%E3%81%95%E3%81%9B%E3%82%8B)

## チェックリスト

- [x]  GitHub で Files changed を確認
- [x]  影響し得る範囲のローカル環境での動作確認